### PR TITLE
UIの修正

### DIFF
--- a/app_flask/app.py
+++ b/app_flask/app.py
@@ -936,6 +936,7 @@ def create_report():
                 return redirect(url_for('create_report'))
             # マークダウンに変換
             html_content = markdown.markdown(report.report_markdown, extensions=["tables"])
+            html_content = f'<div class="table-responsive">{html_content}</div>'
             html_content = html_content.replace('<table>', '<table class="table table-bordered table-dark table-striped">')
             html_content = html_content.replace('<th>', '<th scope="col" class="bg-dark">')
             return render_template(
@@ -981,6 +982,7 @@ def report_list():
 def show_report(report_id):
     report = Report.query.get_or_404(report_id)
     html_content = markdown.markdown(report.report_markdown, extensions=["tables"])
+    html_content = f'<div class="table-responsive">{html_content}</div>'
     html_content = html_content.replace('<table>', '<table class="table table-bordered table-dark table-striped">')
     html_content = html_content.replace('<th>', '<th scope="col" class="bg-dark">')
     return render_template('report_detail.html', report=report, report_html_content=html_content)

--- a/app_flask/templates/api_key.html
+++ b/app_flask/templates/api_key.html
@@ -7,29 +7,45 @@ APIキー設定
 {% endblock %}
 
 {% block content %}
-<div class="d-flex justify-content-center align-items-center min-vh-100">
-    <div class="card bg-custom-dark-2 border-0 shadow-lg p-4 rounded-4 mx-auto" >
+<style>
+    .form-control:hover {
+        background-color: #2a2a2a !important;
+        transition: background-color 0.3s ease;
+    }
+    
+
+    .btn-lg:hover {
+        opacity: 0.75;
+        transition: opacity 0.3s ease;
+    }
+</style>
+
+<div class="container mt-4">
+    <div class="card bg-custom-dark-2 border-0 shadow-lg p-4 rounded-4 mx-auto" style="width: 100%; max-width: 700px;">
         <h2 class="text-center fw-bold mb-4"> APIキー入力</h2>
         
         <form method="POST" action="{{ url_for('api_key') }}">
             <!-- VirusTotal APIキー -->
             <div class="mb-3">
-                <input type="text" name="virustotal_api_key" class="form-control form-control-lg rounded-pill bg-dark text-white border-0"
+                <input type="text" name="virustotal_api_key" class="form-control rounded-pill bg-dark text-white border-0"
                        placeholder="VirusTotal APIキー" required>
             </div>
 
             <!-- malwareBazaar APIキー -->
             <div class="mb-5">
-                <input type="text" name="malwarebazaar_api_key" class="form-control form-control-lg rounded-pill bg-dark text-white border-0"
+                <input type="text" name="malwarebazaar_api_key" class="form-control rounded-pill bg-dark text-white border-0"
                        placeholder="malwareBazaar APIキー" required>
             </div>
 
             <!-- 登録ボタン -->
-            <div class="d-grid">
-                <button type="submit" class="btn btn-lg rounded-pill text-white fw-bold"
-                        style="background: linear-gradient(90deg, #005CFF 0%, #00C2FF 100%);">
-                    保存
-                </button>
+            
+             <div class="row">
+                <div class="col-auto mx-auto">
+                    <button type="submit" class="btn btn-lg rounded-pill text-white fw-bold"
+                            style="background: linear-gradient(90deg, #005CFF 0%, #00C2FF 100%); min-width: 150px; border: none; outline: none;">
+                        保存
+                    </button>
+                </div>
             </div>
         </form>
 

--- a/app_flask/templates/create_report.html
+++ b/app_flask/templates/create_report.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="row justify-content-center">
+<div class="row justify-content-center pt-4">
     <div class="col-md-8 col-lg-6">
         <div class="bg-custom-dark-2 p-4 p-md-5 rounded-3 border border-custom">
             <h2 class="text-center fw-bold mb-3">レポート作成</h2>

--- a/app_flask/templates/home.html
+++ b/app_flask/templates/home.html
@@ -1,37 +1,50 @@
 {% extends "base.html" %}
 
 {% block page_title %}
+ホーム
 {% endblock %}
 
 {% block content %}
-<div class="row justify-content-center">
-    <div class="col-md-8 col-lg-6">
+<style>
+    .btn-custom-home:hover {
+        opacity: 0.75;
+        transition: opacity 0.3s ease;
+    }
+    .btn-no-border {
+        border: none !important;
+        outline: none !important;
+    }
+    .home-card-container {
+        width: 100%;
+        max-width: 600px; /* PC画面での最大幅を600pxに固定 */
+        margin: 0 auto; /* 水平方向を中央に */
+    }
+</style>
+
+<div class="d-flex justify-content-center pt-4">
+    <div class="home-card-container">
         <div class="card bg-custom-dark-2 border border-custom rounded-3">
-            
             <div class="card-header text-center fw-bold">
                 ホーム
             </div>
-
             <div class="card-body">
                 <div class="d-grid gap-3">
                     <a href="/api_key" class="d-grid text-decoration-none">
-                        <button type="button" class="btn btn-lg rounded-pill text-white fw-bold"
+                        <button type="button" class="btn btn-lg rounded-pill text-white fw-bold btn-custom-home btn-no-border"
                                 style="background: linear-gradient(90deg, #005CFF 0%, #00C2FF 100%);">
                             <i class="bi bi-key"></i> APIキーを入力する
                         </button>
                     </a>
-
                     <a href="/create_report" class="d-grid text-decoration-none">
-                        <button type="button" class="btn btn-lg rounded-pill text-white fw-bold"
+                        <button type="button" class="btn btn-lg rounded-pill text-white fw-bold btn-custom-home btn-no-border"
                                 style="background: linear-gradient(90deg, #005CFF 0%, #00C2FF 100%);">
                             <i class="bi bi-file-earmark-plus"></i> レポートを作成する
                         </button>
                     </a>
-
                     <a href="/report_list" class="d-grid text-decoration-none">
-                        <button type="button" class="btn btn-lg rounded-pill text-white fw-bold"
+                        <button type="button" class="btn btn-lg rounded-pill text-white fw-bold btn-custom-home btn-no-border"
                                 style="background: linear-gradient(90deg, #005CFF 0%, #00C2FF 100%);">
-                            <i class="bi bi-list-ol"></i> レポート一覧を見る
+                            <i class="bi bi-list-ul"></i> レポート一覧を見る
                         </button>
                     </a>
                 </div>
@@ -39,8 +52,8 @@
         </div>
     </div>
 </div>
-
 {% endblock %}
 
 {% block scripts %}
+{{ super() }}
 {% endblock %}

--- a/app_flask/templates/report_detail.html
+++ b/app_flask/templates/report_detail.html
@@ -3,19 +3,18 @@
 {% set show_back_button = True %}
 
 {% block page_title %}
-レポート生成結果
+レポート詳細
 {% endblock %}
 
 {% block content %}
 <div class="row">
     <div class="col-12">
-        <h1 class="mb-4 text-white">レポート生成完了</h1>
+        <h1 class="text-center mb-4 text-white">レポート詳細</h1>
         <div class="bg-custom-dark-2 border border-custom rounded-3 p-4 mb-4">
-            <div class="alert alert-success">
-                レポートの生成が完了しました！以下の内容を確認してください。
-            </div>
             <div class="report-content">
-                {{ report_html_content|safe }}
+                <div class="table-responsive">
+                    {{ report_html_content|safe }}
+                </div>
             </div>
         </div>
 
@@ -33,6 +32,5 @@
 
 {% block scripts %}
 {{ super() }}
-<!-- Font Awesome Icons for buttons -->
 <script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script>
 {% endblock %}

--- a/app_flask/templates/report_list.html
+++ b/app_flask/templates/report_list.html
@@ -7,6 +7,14 @@
 {% endblock %}
 
 {% block content %}
+<style>
+    .report-card:hover {
+        background-color: #2a2a2a !important;
+        border-color: #4d4d4d !important;
+        transition: all 0.3s ease;
+    }
+</style>
+
 <div class="container">
     <h1 class="text-center mb-4 text-white">レポート一覧</h1>
     <div class="mb-4">
@@ -18,15 +26,15 @@
     {% if reports %}
         <div class="row">
             {% for report in reports %}
-                <div class="col-md-6 col-lg-4 d-flex">
+                <div class="col-12">
                     <div class="report-card card bg-custom-dark-2 border-custom rounded-3 flex-fill mb-4" onclick="location.href='{{ url_for('show_report', report_id=report.report_id) }}'" style="cursor: pointer;">
-                    <div class="card-body">
+                        <div class="card-body">
                             <h5 class="card-title text-white">{{ report.malware_family }}</h5>
                             <p class="card-text text-secondary mb-1">
                                 <strong>作成日時:</strong> {{ report.created_at.strftime('%Y-%m-%d %H:%M') }}
                             </p>
                             <p class="card-text text-secondary">
-                                <strong>ハッシュ値:</strong> <span class="badge bg-custom-border text-white">{{ report.hash_sha256[:10] }}...</span>
+                                <strong>ハッシュ値:</strong> <span class="hash-display" data-full-hash="{{ report.hash_sha256 }}"></span>
                             </p>
                         </div>
                     </div>
@@ -49,5 +57,35 @@
 {% endblock %}
 
 {% block scripts %}
+<script>
+function truncateHashes() {
+    const hashElements = document.querySelectorAll('.hash-display');
+    const screenWidth = window.innerWidth;
+    let displayLength = 35;
+
+    if (screenWidth > 991) {
+        displayLength = 80;
+    } else if (screenWidth > 767) {
+        displayLength = 50;
+    } else {
+        displayLength = 35;
+    }
+
+    hashElements.forEach(el => {
+        const fullHash = el.getAttribute('data-full-hash');
+        
+        // 修正箇所: ハッシュ値が指定された桁数より長い場合のみ、切り捨てて...を付ける
+        if (fullHash.length > displayLength) {
+            el.textContent = fullHash.substring(0, displayLength) + '...';
+        } else {
+            el.textContent = fullHash; // 元のハッシュ値をそのまま表示
+        }
+    });
+}
+
+// ページのロード時とウィンドウサイズ変更時に実行
+window.addEventListener('load', truncateHashes);
+window.addEventListener('resize', truncateHashes);
+</script>
 {{ super() }}
 {% endblock %}


### PR DESCRIPTION
・ボタンで，カーソルで色が変わるボタンと変わらないボタンがあったので，ホーム画面，APIキー入力画面のボタンを色が変わるように修正した
・ホーム画面のボックスと，APIキー入力のボックスをウィンドウズサイズによって大きさが変わるように修正した（保存ボタンのサイズは固定にした）
・ホーム画面，APIキー入力画面，レポート生成画面の余白を統一した
・レポート一覧画面で，各レポートが縦一列に並べられる形に変更した
・レポート一覧画面で，ハッシュ値の表示方法を改良した
・レポート単体表示画面のレポートの生成が完了しましたというメッセージを削除した
・レポート結果画面の表がはみ出ないように修正した

