### PR TITLE
いくつかの機能修正

### DIFF
--- a/app_flask/templates/api_key.html
+++ b/app_flask/templates/api_key.html
@@ -18,12 +18,30 @@ APIキー設定
         opacity: 0.75;
         transition: opacity 0.3s ease;
     }
+
+    .btn-custom-secondary {
+        background-color: var(--custom-dark-2);
+        border: 1px solid var(--custom-border);
+        color: var(--custom-text);
+        transition: all 0.3s ease;
+    }
+
+    .btn-custom-secondary:hover {
+        background-color: var(--custom-border);
+        color: white;
+    }
 </style>
 
 <div class="container mt-4">
     <div class="card bg-custom-dark-2 border-0 shadow-lg p-4 rounded-4 mx-auto" style="width: 100%; max-width: 700px;">
         <h2 class="text-center fw-bold mb-4"> APIキー入力</h2>
         
+        {% if is_key_registered %}
+        <div class="alert alert-success text-center" role="alert">
+            APIキーはすでに登録済みです。
+        </div>
+        {% endif %}
+
         <form method="POST" action="{{ url_for('api_key') }}">
             <!-- VirusTotal APIキー -->
             <div class="mb-3">
@@ -39,13 +57,14 @@ APIキー設定
 
             <!-- 登録ボタン -->
             
-             <div class="row">
-                <div class="col-auto mx-auto">
-                    <button type="submit" class="btn btn-lg rounded-pill text-white fw-bold"
-                            style="background: linear-gradient(90deg, #005CFF 0%, #00C2FF 100%); min-width: 150px; border: none; outline: none;">
-                        保存
-                    </button>
-                </div>
+             <div class="d-flex justify-content-center gap-3">
+                <a href="{{ url_for('home') }}" class="btn btn-lg rounded-pill fw-bold btn-custom-secondary" style="min-width: 150px;">
+                    ホームに戻る
+                </a>
+                <button type="submit" class="btn btn-lg rounded-pill text-white fw-bold"
+                        style="background: linear-gradient(90deg, #005CFF 0%, #00C2FF 100%); min-width: 150px; border: none; outline: none;">
+                    保存
+                </button>
             </div>
         </form>
 

--- a/app_flask/templates/base.html
+++ b/app_flask/templates/base.html
@@ -66,23 +66,21 @@
     {% if show_header|default(True) %}
     <header class="bg-custom-dark-2 border-bottom border-custom sticky-top">
         {% block header %}
-        <nav class="navbar">
-            <div class="container-fluid position-relative d-flex justify-content-between">
-                
-                <div>
-                    {% if show_back_button %}
-                    <button onclick="history.back()" class="btn btn-logout">
-                        <i class="bi bi-arrow-left"></i> 戻る
-                    </button>
-                    {% endif %}
-                </div>
+<nav class="navbar">
+    <div class="container-fluid d-flex flex-column align-items-center py-2">
+        <a class="navbar-brand mb-2 h1 fs-5" href="{{ url_for('home') }}">
+            {% block header_title %}Malware-Analysis-OSINT-Tool{% endblock %}
+        </a>
 
-                <div class="position-absolute top-50 start-50 translate-middle">
-                    <a class="navbar-brand mb-0 h1 fs-5" href="{{ url_for('home') }}">
-                        {% block header_title %}Malware-Analysis-OSINT-Tool{% endblock %}
-                    </a>
-                </div>
-
+        <div class="d-flex justify-content-between w-100">
+            <div>
+                {% if show_back_button %}
+                <button onclick="history.back()" class="btn btn-logout">
+                    <i class="bi bi-arrow-left"></i> 戻る
+                </button>
+                {% endif %}
+            </div>
+            <div>
                 {% if current_user.is_authenticated %}
                 <div class="dropdown">
                     <button class="btn btn-logout dropdown-toggle" type="button" id="userMenu" data-bs-toggle="dropdown" aria-expanded="false">
@@ -94,10 +92,14 @@
                         <li><a class="dropdown-item" href="{{ url_for('logout') }}">ログアウト</a></li>
                     </ul>
                 </div>
+                {% else %}
+                <a href="{{ url_for('login') }}" class="btn btn-logout">ログイン</a>
                 {% endif %}
             </div>
-        </nav>
-        {% endblock %}
+        </div>
+    </div>
+</nav>
+{% endblock %}
     </header>
     {% endif %}
 

--- a/app_flask/templates/create_report.html
+++ b/app_flask/templates/create_report.html
@@ -6,9 +6,6 @@
 レポート作成
 {% endblock %}
 
-{% block header_title %}
-マルウェア解析ツール
-{% endblock %}
 
 {% block content %}
 <div class="row justify-content-center pt-4">

--- a/app_flask/templates/report_detail.html
+++ b/app_flask/templates/report_detail.html
@@ -18,10 +18,7 @@
             </div>
         </div>
 
-        <div class="d-flex justify-content-between">
-            <a href="{{ url_for('create_report') }}" class="btn btn-secondary">
-                <i class="fas fa-arrow-left"></i> 別のレポートを作成
-            </a>
+        <div class="d-flex justify-content-center">
             <a href="{{ url_for('report_list') }}" class="btn btn-primary">
                 レポート一覧へ
             </a>

--- a/app_flask/templates/signup.html
+++ b/app_flask/templates/signup.html
@@ -13,8 +13,8 @@
         <form method="POST" action="{{ url_for('signup') }}">
             <!-- ユーザー名 -->
             <div class="mb-3">
-                <input type="user" name="user" class="form-control form-control-lg rounded-pill bg-dark text-white border-0"
-                       placeholder="ユーザー名" required>
+                <input type="text" name="user" class="form-control form-control-lg rounded-pill bg-dark text-white border-0"
+                       placeholder="ユーザー名" maxlength="20" required>
             </div>
 
             <!-- パスワード -->


### PR DESCRIPTION
○レポート詳細画面に，別のレポートを作成ボタンはいらない
○APIキーを保存したらホームに戻るボタンが必要
○APIキーが入力済みか一目で分かるようにしたい
入力したAPIキーが表示できる機能をつけるのはどうか
○アカウントボタンが重なっている
○ユーザー名文字数制限（20文字）
○ヘッターのタイトルがレポート作成画面だけ日本語
○APIキーを入力したら，自動でホームに戻し，保存されましたメッセージはホームで表示したい
○エラーメッセージで，APIが無効だった場合のメッセージも追加したい
